### PR TITLE
Add Spring Boot mock for IT Glue API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,52 @@
-# itglue-mock
+# IT Glue Mock API
+
+A mock implementation of a subset of the [IT Glue API](https://api.itglue.com/developer/) built with Spring Boot. It is designed so you can run local proof-of-concept integrations and later swap to the real IT Glue service without changing request signatures.
+
+## Features
+
+- JSON:API compliant endpoints for frequently used IT Glue resources (`/configurations`, `/organizations`, `/locations`, etc.).
+- `/search` endpoint that mirrors IT Glue's search parameters, including pagination, filtering by resource type and organization, and JSON:API pagination metadata.
+- Relationship endpoints such as `/configurations/{id}/relationships/organization` and `/configurations/{id}/organization`.
+- Data loaded from editable JSON fixtures located in `src/main/resources/data`. Update these files to change the mock responses or add new records.
+
+## Getting started
+
+### Prerequisites
+
+- Java 21+
+- Maven 3.9+
+
+### Run the mock API
+
+```bash
+mvn spring-boot:run
+```
+
+The application starts on port `8080`. Example requests:
+
+- `GET http://localhost:8080/search?query=acme&filter[resource_type]=configurations`
+- `GET http://localhost:8080/configurations/100?include=organization,location,primary-contact`
+- `GET http://localhost:8080/configurations/100/relationships/passwords`
+- `GET http://localhost:8080/passwords/1`
+
+### Modifying mock data
+
+Mock data is defined with JSON:API compliant documents in `src/main/resources/data`. To add another workstation, append a new resource to `configurations.json` and reference any related records using the `relationships` node. Restart the Spring Boot application to reload the data.
+
+### Tests
+
+Run the unit tests with:
+
+```bash
+mvn test
+```
+
+## Project structure
+
+- `src/main/java/com/example/itgluemock` – Spring Boot application and controllers.
+- `src/main/resources/data` – JSON fixtures for each IT Glue resource type.
+
+## Notes
+
+- Authentication and rate limiting are not enforced, allowing fast iterations during local development.
+- Error responses follow the JSON:API `errors` format to make the mock behaviour align with the production service.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,52 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>itglue-mock</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>IT Glue Mock API</name>
+    <description>Mock implementation of the IT Glue API</description>
+    <properties>
+        <java.version>21</java.version>
+        <spring.boot.version>3.3.5</spring.boot.version>
+    </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring.boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring.boot.version}</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/itgluemock/ItGlueMockApplication.java
+++ b/src/main/java/com/example/itgluemock/ItGlueMockApplication.java
@@ -1,0 +1,12 @@
+package com.example.itgluemock;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class ItGlueMockApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(ItGlueMockApplication.class, args);
+    }
+}

--- a/src/main/java/com/example/itgluemock/controller/ApiExceptionHandler.java
+++ b/src/main/java/com/example/itgluemock/controller/ApiExceptionHandler.java
@@ -1,0 +1,55 @@
+package com.example.itgluemock.controller;
+
+import com.example.itgluemock.exception.BadRequestException;
+import com.example.itgluemock.exception.ResourceNotFoundException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ApiExceptionHandler {
+
+    private final ObjectMapper objectMapper;
+
+    public ApiExceptionHandler(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<ObjectNode> handleNotFound(ResourceNotFoundException ex) {
+        return buildErrorResponse(HttpStatus.NOT_FOUND, "Resource Not Found", ex.getMessage());
+    }
+
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<ObjectNode> handleBadRequest(BadRequestException ex) {
+        return buildErrorResponse(HttpStatus.BAD_REQUEST, "Bad Request", ex.getMessage());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ObjectNode> handleUnexpected(Exception ex) {
+        return buildErrorResponse(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                "Internal Server Error",
+                "An unexpected error occurred");
+    }
+
+    private ResponseEntity<ObjectNode> buildErrorResponse(HttpStatus status, String title, String detail) {
+        ObjectNode error = objectMapper.createObjectNode();
+        error.put("status", Integer.toString(status.value()));
+        error.put("title", title);
+        error.put("detail", detail);
+
+        ArrayNode errors = objectMapper.createArrayNode();
+        errors.add(error);
+
+        ObjectNode document = objectMapper.createObjectNode();
+        document.set("errors", errors);
+
+        return ResponseEntity.status(status).contentType(MediaType.APPLICATION_JSON).body(document);
+    }
+}

--- a/src/main/java/com/example/itgluemock/controller/ResourceController.java
+++ b/src/main/java/com/example/itgluemock/controller/ResourceController.java
@@ -1,0 +1,140 @@
+package com.example.itgluemock.controller;
+
+import com.example.itgluemock.exception.ResourceNotFoundException;
+import com.example.itgluemock.store.JsonApiDataStore;
+import com.example.itgluemock.store.JsonApiDataStore.IncludeTree;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+public class ResourceController {
+
+    private final JsonApiDataStore dataStore;
+    private final ObjectMapper objectMapper;
+
+    public ResourceController(JsonApiDataStore dataStore, ObjectMapper objectMapper) {
+        this.dataStore = dataStore;
+        this.objectMapper = objectMapper;
+    }
+
+    @GetMapping("/{resourceType:^(?!search$).+}")
+    public ResponseEntity<JsonNode> listResources(
+            @PathVariable String resourceType,
+            @RequestParam(name = "page[size]", defaultValue = "25") int pageSize,
+            @RequestParam(name = "page[number]", defaultValue = "1") int pageNumber,
+            @RequestParam(name = "include", required = false) String includeParam) {
+        validateResourceType(resourceType);
+        IncludeTree includeTree = dataStore.parseIncludeParameter(includeParam);
+        ObjectNode document =
+                dataStore.buildCollectionDocument(resourceType, pageSize, pageNumber, includeTree);
+        return ResponseEntity.ok(document);
+    }
+
+    @GetMapping("/{resourceType:^(?!search$).+}/{id}")
+    public ResponseEntity<JsonNode> fetchResource(
+            @PathVariable String resourceType,
+            @PathVariable String id,
+            @RequestParam(name = "include", required = false) String includeParam) {
+        validateResourceType(resourceType);
+        IncludeTree includeTree = dataStore.parseIncludeParameter(includeParam);
+        return dataStore
+                .buildResourceDocument(resourceType, id, includeTree)
+                .map(ResponseEntity::ok)
+                .orElseThrow(() -> new ResourceNotFoundException(resourceType + " " + id + " not found"));
+    }
+
+    @GetMapping("/{resourceType:^(?!search$).+}/{id}/relationships/{relationship}")
+    public ResponseEntity<JsonNode> fetchRelationship(
+            @PathVariable String resourceType,
+            @PathVariable String id,
+            @PathVariable String relationship) {
+        validateResourceType(resourceType);
+        return dataStore
+                .buildRelationshipDocument(resourceType, id, relationship)
+                .map(ResponseEntity::ok)
+                .orElseThrow(
+                        () ->
+                                new ResourceNotFoundException(
+                                        "Relationship "
+                                                + relationship
+                                                + " for "
+                                                + resourceType
+                                                + " "
+                                                + id
+                                                + " not found"));
+    }
+
+    @GetMapping("/{resourceType:^(?!search$).+}/{id}/{relatedResource}")
+    public ResponseEntity<JsonNode> fetchRelatedResources(
+            @PathVariable String resourceType,
+            @PathVariable String id,
+            @PathVariable String relatedResource) {
+        validateResourceType(resourceType);
+        JsonNode relationshipData =
+                dataStore
+                        .buildRelationshipDocument(resourceType, id, relatedResource)
+                        .map(doc -> doc.path("data"))
+                        .orElseThrow(
+                                () ->
+                                        new ResourceNotFoundException(
+                                                "Relationship "
+                                                        + relatedResource
+                                                        + " for "
+                                                        + resourceType
+                                                        + " "
+                                                        + id
+                                                        + " not found"));
+
+        ObjectNode document = objectMapper.createObjectNode();
+        if (relationshipData.isMissingNode() || relationshipData.isNull()) {
+            document.putNull("data");
+            return ResponseEntity.ok(document);
+        }
+
+        if (relationshipData.isArray()) {
+            ArrayNode data = objectMapper.createArrayNode();
+            for (JsonNode related : relationshipData) {
+                String type = related.path("type").asText();
+                String relatedId = related.path("id").asText();
+                JsonNode resource =
+                        dataStore
+                                .findResource(type, relatedId)
+                                .orElseThrow(
+                                        () ->
+                                                new ResourceNotFoundException(
+                                                        type + " " + relatedId + " not found"));
+                data.add(resource);
+            }
+            document.set("data", data);
+        } else {
+            String type = relationshipData.path("type").asText();
+            String relatedId = relationshipData.path("id").asText();
+            JsonNode resource =
+                    dataStore
+                            .findResource(type, relatedId)
+                            .orElseThrow(
+                                    () ->
+                                            new ResourceNotFoundException(
+                                                    type + " " + relatedId + " not found"));
+            document.set("data", resource);
+        }
+
+        return ResponseEntity.ok(document);
+    }
+
+    private void validateResourceType(String resourceType) {
+        if (!dataStore.hasResourceType(resourceType)) {
+            throw new ResourceNotFoundException("Resource type " + resourceType + " not found");
+        }
+    }
+}

--- a/src/main/java/com/example/itgluemock/controller/SearchController.java
+++ b/src/main/java/com/example/itgluemock/controller/SearchController.java
@@ -1,0 +1,63 @@
+package com.example.itgluemock.controller;
+
+import com.example.itgluemock.service.SearchService;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(value = "/search", produces = MediaType.APPLICATION_JSON_VALUE)
+public class SearchController {
+
+    private final SearchService searchService;
+
+    public SearchController(SearchService searchService) {
+        this.searchService = searchService;
+    }
+
+    @GetMapping
+    public ResponseEntity<JsonNode> search(
+            @RequestParam(name = "query") String query,
+            @RequestParam(name = "page[size]", defaultValue = "25") int pageSize,
+            @RequestParam(name = "page[number]", defaultValue = "1") int pageNumber,
+            @RequestParam MultiValueMap<String, String> rawParams) {
+        java.util.Set<String> resourceTypes = ResourceTypeParser.parse(rawParams.get("filter[resource_type]"));
+        String organizationId = rawParams.getFirst("filter[organization_id]");
+        JsonNode result =
+                searchService.search(
+                        query,
+                        pageSize,
+                        pageNumber,
+                        resourceTypes,
+                        java.util.Optional.ofNullable(organizationId));
+        return ResponseEntity.ok(result);
+    }
+
+    private static class ResourceTypeParser {
+        private ResourceTypeParser() {}
+
+        static java.util.Set<String> parse(java.util.List<String> rawValues) {
+            if (rawValues == null || rawValues.isEmpty()) {
+                return java.util.Set.of();
+            }
+            java.util.Set<String> values = new java.util.LinkedHashSet<>();
+            for (String value : rawValues) {
+                if (value == null) {
+                    continue;
+                }
+                for (String token : value.split(",")) {
+                    String trimmed = token.trim();
+                    if (!trimmed.isEmpty()) {
+                        values.add(trimmed);
+                    }
+                }
+            }
+            return values;
+        }
+    }
+}

--- a/src/main/java/com/example/itgluemock/exception/BadRequestException.java
+++ b/src/main/java/com/example/itgluemock/exception/BadRequestException.java
@@ -1,0 +1,7 @@
+package com.example.itgluemock.exception;
+
+public class BadRequestException extends RuntimeException {
+    public BadRequestException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/itgluemock/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/example/itgluemock/exception/ResourceNotFoundException.java
@@ -1,0 +1,7 @@
+package com.example.itgluemock.exception;
+
+public class ResourceNotFoundException extends RuntimeException {
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/itgluemock/service/SearchService.java
+++ b/src/main/java/com/example/itgluemock/service/SearchService.java
@@ -1,0 +1,192 @@
+package com.example.itgluemock.service;
+
+import com.example.itgluemock.exception.BadRequestException;
+import com.example.itgluemock.exception.ResourceNotFoundException;
+import com.example.itgluemock.store.JsonApiDataStore;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+
+@Service
+public class SearchService {
+
+    private final JsonApiDataStore dataStore;
+    private final ObjectMapper objectMapper;
+
+    public SearchService(JsonApiDataStore dataStore, ObjectMapper objectMapper) {
+        this.dataStore = dataStore;
+        this.objectMapper = objectMapper;
+    }
+
+    public ObjectNode search(
+            String query,
+            int pageSize,
+            int pageNumber,
+            Set<String> resourceTypes,
+            Optional<String> organizationIdFilter) {
+        if (query == null || query.isBlank()) {
+            throw new BadRequestException("query parameter is required");
+        }
+
+        Set<String> normalizedTypes = normalizeResourceTypes(resourceTypes);
+        String normalizedQuery = query.toLowerCase(Locale.ROOT);
+
+        List<JsonNode> candidates = selectCandidates(normalizedTypes);
+
+        List<JsonNode> filtered = candidates.stream()
+                .filter(node -> matchesQuery(node, normalizedQuery))
+                .filter(node -> matchesOrganizationFilter(node, organizationIdFilter))
+                .sorted(compareByDisplayName())
+                .collect(java.util.stream.Collectors.toCollection(java.util.ArrayList::new));
+
+        int validatedPageSize = pageSize <= 0 ? 25 : pageSize;
+        int validatedPageNumber = Math.max(pageNumber, 1);
+        int total = filtered.size();
+        int fromIndex = Math.min((validatedPageNumber - 1) * validatedPageSize, total);
+        int toIndex = Math.min(fromIndex + validatedPageSize, total);
+        List<JsonNode> page = filtered.subList(fromIndex, toIndex);
+
+        ArrayNode data = objectMapper.createArrayNode();
+        page.stream().map(JsonNode::deepCopy).forEach(data::add);
+
+        ObjectNode document = objectMapper.createObjectNode();
+        document.set("data", data);
+        document.set("meta", buildMeta(total, validatedPageSize, validatedPageNumber));
+        document.set(
+                "links",
+                buildLinks(query, validatedPageSize, validatedPageNumber, total, normalizedTypes));
+        return document;
+    }
+
+    private List<JsonNode> selectCandidates(Set<String> resourceTypes) {
+        if (resourceTypes.isEmpty()) {
+            return dataStore.resourceTypes().stream()
+                    .flatMap(type -> dataStore.findResources(type).stream())
+                    .map(JsonNode::deepCopy)
+                    .toList();
+        }
+        List<JsonNode> results = new ArrayList<>();
+        for (String type : resourceTypes) {
+            if (!dataStore.hasResourceType(type)) {
+                throw new ResourceNotFoundException("Resource type " + type + " not found");
+            }
+            results.addAll(dataStore.findResources(type));
+        }
+        return results;
+    }
+
+    private Set<String> normalizeResourceTypes(Set<String> resourceTypes) {
+        if (resourceTypes == null || resourceTypes.isEmpty()) {
+            return Set.of();
+        }
+        Set<String> normalized = new LinkedHashSet<>();
+        for (String type : resourceTypes) {
+            if (type == null) {
+                continue;
+            }
+            String trimmed = type.trim();
+            if (!trimmed.isEmpty()) {
+                normalized.add(trimmed);
+            }
+        }
+        return normalized;
+    }
+
+    private boolean matchesQuery(JsonNode node, String query) {
+        if (node.path("id").asText().toLowerCase(Locale.ROOT).contains(query)) {
+            return true;
+        }
+        JsonNode attributes = node.path("attributes");
+        return searchAttributes(attributes, query);
+    }
+
+    private boolean searchAttributes(JsonNode node, String query) {
+        if (node == null || node.isMissingNode() || node.isNull()) {
+            return false;
+        }
+        if (node.isValueNode()) {
+            return node.asText("").toLowerCase(Locale.ROOT).contains(query);
+        }
+        if (node.isArray()) {
+            for (JsonNode element : node) {
+                if (searchAttributes(element, query)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        if (node.isObject()) {
+            for (JsonNode value : node) {
+                if (searchAttributes(value, query)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private boolean matchesOrganizationFilter(JsonNode node, Optional<String> organizationId) {
+        if (organizationId.isEmpty()) {
+            return true;
+        }
+        JsonNode relationship = node.path("relationships").path("organization").path("data");
+        return organizationId
+                .map(id -> id.equals(relationship.path("id").asText()))
+                .orElse(true);
+    }
+
+    private Comparator<JsonNode> compareByDisplayName() {
+        return Comparator.comparing(
+                node -> node.path("attributes").path("name").asText(node.path("id").asText()),
+                String.CASE_INSENSITIVE_ORDER);
+    }
+
+    private ObjectNode buildMeta(int total, int pageSize, int pageNumber) {
+        ObjectNode meta = objectMapper.createObjectNode();
+        meta.put("total-count", total);
+        meta.put("page-size", pageSize);
+        meta.put("page-number", pageNumber);
+        int pageCount = pageSize == 0 ? 1 : (int) Math.ceil(total / (double) pageSize);
+        meta.put("page-count", Math.max(pageCount, 1));
+        return meta;
+    }
+
+    private ObjectNode buildLinks(
+            String query,
+            int pageSize,
+            int pageNumber,
+            int total,
+            Set<String> resourceTypes) {
+        ObjectNode links = objectMapper.createObjectNode();
+        String base = new StringBuilder("/search?query=")
+                .append(query)
+                .append("&page[size]=")
+                .append(pageSize)
+                .toString();
+        if (!resourceTypes.isEmpty()) {
+            String joined = resourceTypes.stream().collect(Collectors.joining(","));
+            base += "&filter[resource_type]=" + joined;
+        }
+        links.put("self", base + "&page[number]=" + pageNumber);
+        links.put("first", base + "&page[number]=1");
+        int pageCount = pageSize == 0 ? 1 : (int) Math.ceil(total / (double) pageSize);
+        links.put("last", base + "&page[number]=" + Math.max(pageCount, 1));
+        if (pageNumber > 1) {
+            links.put("prev", base + "&page[number]=" + (pageNumber - 1));
+        }
+        if (pageNumber < pageCount) {
+            links.put("next", base + "&page[number]=" + (pageNumber + 1));
+        }
+        return links;
+    }
+}

--- a/src/main/java/com/example/itgluemock/store/JsonApiDataStore.java
+++ b/src/main/java/com/example/itgluemock/store/JsonApiDataStore.java
@@ -1,0 +1,329 @@
+package com.example.itgluemock.store;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.stereotype.Component;
+
+/**
+ * Loads JSON:API resource documents from {@code classpath:data/*.json} files and exposes utility
+ * methods to build JSON:API compliant responses.
+ */
+@Component
+public class JsonApiDataStore {
+
+    private final ObjectMapper objectMapper;
+    private final Map<String, Map<String, ObjectNode>> resourcesByType = new LinkedHashMap<>();
+
+    public JsonApiDataStore(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+        loadDataFiles();
+    }
+
+    public boolean hasResourceType(String resourceType) {
+        return resourcesByType.containsKey(resourceType);
+    }
+
+    public Set<String> resourceTypes() {
+        return Collections.unmodifiableSet(resourcesByType.keySet());
+    }
+
+    public ObjectNode buildCollectionDocument(
+            String resourceType, int pageSize, int pageNumber, IncludeTree includeTree) {
+        List<ObjectNode> resources = new ArrayList<>(
+                resourcesByType.getOrDefault(resourceType, Collections.emptyMap()).values());
+        int total = resources.size();
+        if (total == 0) {
+            return emptyDocument();
+        }
+
+        int validatedPageSize = pageSize <= 0 ? total : pageSize;
+        int validatedPageNumber = Math.max(pageNumber, 1);
+        int fromIndex = Math.min((validatedPageNumber - 1) * validatedPageSize, total);
+        int toIndex = Math.min(fromIndex + validatedPageSize, total);
+        List<ObjectNode> page = resources.subList(fromIndex, toIndex);
+
+        ArrayNode data = objectMapper.createArrayNode();
+        page.stream().map(ObjectNode::deepCopy).forEach(data::add);
+
+        ObjectNode document = objectMapper.createObjectNode();
+        document.set("data", data);
+        document.set("meta", buildMeta(total, validatedPageSize, validatedPageNumber));
+        document.set(
+                "links",
+                buildPaginationLinks(
+                        resourceType, total, validatedPageSize, validatedPageNumber));
+
+        ArrayNode included = collectIncludedResources(page, includeTree);
+        if (included.size() > 0) {
+            document.set("included", included);
+        }
+        return document;
+    }
+
+    public Optional<ObjectNode> buildResourceDocument(
+            String resourceType, String id, IncludeTree includeTree) {
+        return Optional.ofNullable(resourcesByType.getOrDefault(resourceType, Map.of()).get(id))
+                .map(ObjectNode::deepCopy)
+                .map(resource -> enrichResourceDocument(resource, includeTree));
+    }
+
+    public Optional<ObjectNode> buildRelationshipDocument(
+            String resourceType, String id, String relationshipName) {
+        ObjectNode resource = resourcesByType.getOrDefault(resourceType, Map.of()).get(id);
+        if (resource == null) {
+            return Optional.empty();
+        }
+
+        JsonNode relationships = resource.path("relationships");
+        if (!relationships.has(relationshipName)) {
+            return Optional.empty();
+        }
+
+        JsonNode relationshipNode = relationships.path(relationshipName).path("data");
+        ObjectNode document = objectMapper.createObjectNode();
+        document.set("data", relationshipNode.deepCopy());
+        return Optional.of(document);
+    }
+
+    public List<ObjectNode> findResources(String resourceType) {
+        return new ArrayList<>(
+                resourcesByType.getOrDefault(resourceType, Collections.emptyMap()).values());
+    }
+
+    public Optional<ObjectNode> findResource(String resourceType, String id) {
+        return Optional.ofNullable(resourcesByType.getOrDefault(resourceType, Map.of()).get(id))
+                .map(ObjectNode::deepCopy);
+    }
+
+    public IncludeTree parseIncludeParameter(String includeParam) {
+        if (includeParam == null || includeParam.isBlank()) {
+            return IncludeTree.empty();
+        }
+        String[] paths = includeParam.split(",");
+        IncludeTree root = IncludeTree.empty();
+        for (String path : paths) {
+            String trimmed = path.trim();
+            if (!trimmed.isEmpty()) {
+                root = root.merge(IncludeTree.fromPath(trimmed));
+            }
+        }
+        return root;
+    }
+
+    private ObjectNode enrichResourceDocument(ObjectNode resource, IncludeTree includeTree) {
+        ObjectNode document = objectMapper.createObjectNode();
+        document.set("data", resource);
+        ArrayNode included = collectIncludedResources(List.of(resource), includeTree);
+        if (included.size() > 0) {
+            document.set("included", included);
+        }
+        return document;
+    }
+
+    private ArrayNode collectIncludedResources(List<ObjectNode> resources, IncludeTree includeTree) {
+        ArrayNode included = objectMapper.createArrayNode();
+        if (includeTree.isEmpty()) {
+            return included;
+        }
+
+        Set<String> visited = new HashSet<>();
+        Deque<IncludeRequest> queue = new ArrayDeque<>();
+        for (ObjectNode resource : resources) {
+            queue.add(new IncludeRequest(resource, includeTree));
+        }
+
+        while (!queue.isEmpty()) {
+            IncludeRequest request = queue.pollFirst();
+            ObjectNode relationships = request.resource().with("relationships");
+            for (Map.Entry<String, IncludeTree> entry : request.includeTree().children().entrySet()) {
+                String relationshipName = entry.getKey();
+                JsonNode relationship = relationships.path(relationshipName).path("data");
+                if (relationship.isMissingNode() || relationship.isNull()) {
+                    continue;
+                }
+
+                if (relationship.isArray()) {
+                    for (JsonNode node : relationship) {
+                        addIncludedResource(
+                                node.path("type").asText(),
+                                node.path("id").asText(),
+                                entry.getValue(),
+                                visited,
+                                included,
+                                queue);
+                    }
+                } else {
+                    addIncludedResource(
+                            relationship.path("type").asText(),
+                            relationship.path("id").asText(),
+                            entry.getValue(),
+                            visited,
+                            included,
+                            queue);
+                }
+            }
+        }
+
+        return included;
+    }
+
+    private void addIncludedResource(
+            String type,
+            String id,
+            IncludeTree nestedIncludes,
+            Set<String> visited,
+            ArrayNode included,
+            Deque<IncludeRequest> queue) {
+        if (type == null || id == null || type.isEmpty() || id.isEmpty()) {
+            return;
+        }
+        String key = type + ":" + id;
+        if (visited.contains(key)) {
+            return;
+        }
+        ObjectNode resource =
+                resourcesByType.getOrDefault(type, Collections.emptyMap()).get(id);
+        if (resource == null) {
+            return;
+        }
+        visited.add(key);
+        ObjectNode copy = resource.deepCopy();
+        included.add(copy);
+        if (!nestedIncludes.isEmpty()) {
+            queue.add(new IncludeRequest(copy, nestedIncludes));
+        }
+    }
+
+    private ObjectNode buildMeta(int total, int pageSize, int pageNumber) {
+        ObjectNode meta = objectMapper.createObjectNode();
+        meta.put("total-count", total);
+        meta.put("page-size", pageSize);
+        meta.put("page-number", pageNumber);
+        int pageCount = pageSize == 0 ? 1 : (int) Math.ceil(total / (double) pageSize);
+        meta.put("page-count", Math.max(pageCount, 1));
+        return meta;
+    }
+
+    private ObjectNode buildPaginationLinks(
+            String resourceType, int total, int pageSize, int pageNumber) {
+        ObjectNode links = objectMapper.createObjectNode();
+        String base = "/" + resourceType + "?page[size]=" + pageSize;
+        links.put("self", base + "&page[number]=" + pageNumber);
+        links.put("first", base + "&page[number]=1");
+        int pageCount = pageSize == 0 ? 1 : (int) Math.ceil(total / (double) pageSize);
+        links.put("last", base + "&page[number]=" + Math.max(pageCount, 1));
+        if (pageNumber > 1) {
+            links.put("prev", base + "&page[number]=" + (pageNumber - 1));
+        }
+        if (pageNumber < pageCount) {
+            links.put("next", base + "&page[number]=" + (pageNumber + 1));
+        }
+        return links;
+    }
+
+    private ObjectNode emptyDocument() {
+        ObjectNode document = objectMapper.createObjectNode();
+        document.set("data", objectMapper.createArrayNode());
+        return document;
+    }
+
+    private void loadDataFiles() {
+        PathMatchingResourcePatternResolver resolver =
+                new PathMatchingResourcePatternResolver(getClass().getClassLoader());
+        try {
+            Resource[] resources = resolver.getResources("classpath:data/*.json");
+            for (Resource resource : resources) {
+                loadResourceFile(resource);
+            }
+        } catch (IOException ex) {
+            throw new IllegalStateException("Failed to load mock data files", ex);
+        }
+    }
+
+    private void loadResourceFile(Resource resource) throws IOException {
+        try (InputStream inputStream = resource.getInputStream()) {
+            JsonNode document = objectMapper.readTree(inputStream);
+            if (document == null || !document.has("data")) {
+                return;
+            }
+            registerNodes(document.path("data"));
+            registerNodes(document.path("included"));
+        }
+    }
+
+    private void registerNodes(JsonNode nodes) {
+        if (nodes == null || !nodes.isArray()) {
+            return;
+        }
+        for (JsonNode node : nodes) {
+            if (node instanceof ObjectNode objectNode) {
+                String type = objectNode.path("type").asText(null);
+                String id = objectNode.path("id").asText(null);
+                if (type == null || id == null) {
+                    continue;
+                }
+                resourcesByType
+                        .computeIfAbsent(type, key -> new LinkedHashMap<>())
+                        .put(id, objectNode);
+            }
+        }
+    }
+
+    public record IncludeTree(Map<String, IncludeTree> children) {
+
+        public static IncludeTree empty() {
+            return new IncludeTree(Map.of());
+        }
+
+        public static IncludeTree fromPath(String path) {
+            String[] segments = path.split("\\.");
+            return buildTree(segments, 0);
+        }
+
+        private static IncludeTree buildTree(String[] segments, int index) {
+            if (index >= segments.length) {
+                return empty();
+            }
+            String segment = segments[index];
+            return new IncludeTree(
+                    Map.of(segment, buildTree(segments, index + 1)));
+        }
+
+        public IncludeTree merge(IncludeTree other) {
+            if (this.isEmpty()) {
+                return other;
+            }
+            if (other.isEmpty()) {
+                return this;
+            }
+            Map<String, IncludeTree> merged = new HashMap<>(this.children);
+            for (Map.Entry<String, IncludeTree> entry : other.children.entrySet()) {
+                merged.merge(entry.getKey(), entry.getValue(), IncludeTree::merge);
+            }
+            return new IncludeTree(Collections.unmodifiableMap(merged));
+        }
+
+        public boolean isEmpty() {
+            return children.isEmpty();
+        }
+    }
+
+    private record IncludeRequest(ObjectNode resource, IncludeTree includeTree) {}
+}

--- a/src/main/resources/data/configuration-types.json
+++ b/src/main/resources/data/configuration-types.json
@@ -1,0 +1,24 @@
+{
+  "data": [
+    {
+      "type": "configuration-types",
+      "id": "1",
+      "attributes": {
+        "name": "Workstation",
+        "category": "Hardware",
+        "created-at": "2020-06-01T12:00:00Z",
+        "updated-at": "2024-08-22T16:30:00Z"
+      }
+    },
+    {
+      "type": "configuration-types",
+      "id": "2",
+      "attributes": {
+        "name": "Server",
+        "category": "Hardware",
+        "created-at": "2019-03-15T09:00:00Z",
+        "updated-at": "2024-05-12T10:45:00Z"
+      }
+    }
+  ]
+}

--- a/src/main/resources/data/configurations.json
+++ b/src/main/resources/data/configurations.json
@@ -1,0 +1,114 @@
+{
+  "data": [
+    {
+      "type": "configurations",
+      "id": "100",
+      "attributes": {
+        "name": "ACME-WS-01",
+        "hostname": "acme-ws-01",
+        "serial-number": "ACMEWS01SN",
+        "asset-tag": "WS-001",
+        "status": "Active",
+        "primary-ip": "10.0.10.15",
+        "primary-mac-address": "00-16-3E-5D-78-01",
+        "operating-system": "Windows 11 Pro",
+        "os-licence-key": "XXXXX-XXXXX-XXXXX-XXXXX-AAAAA",
+        "processor": "Intel Core i7-11700",
+        "memory": "32 GB",
+        "storage": "1 TB NVMe SSD",
+        "last-logged-in-user": "maria.lopez",
+        "notes": "Primary workstation for Maria Lopez. Critical for firewall troubleshooting tickets.",
+        "installed-at": "2023-02-21T09:30:00Z",
+        "warranty-expiration": "2026-02-21"
+      },
+      "relationships": {
+        "organization": {
+          "data": {
+            "type": "organizations",
+            "id": "1"
+          }
+        },
+        "location": {
+          "data": {
+            "type": "locations",
+            "id": "1"
+          }
+        },
+        "configuration-type": {
+          "data": {
+            "type": "configuration-types",
+            "id": "1"
+          }
+        },
+        "primary-contact": {
+          "data": {
+            "type": "contacts",
+            "id": "1"
+          }
+        },
+        "passwords": {
+          "data": [
+            {
+              "type": "passwords",
+              "id": "1"
+            },
+            {
+              "type": "passwords",
+              "id": "2"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "configurations",
+      "id": "200",
+      "attributes": {
+        "name": "GLOBEX-SRV-CORE",
+        "hostname": "globex-srv-core",
+        "serial-number": "GLOBEXSRV01",
+        "asset-tag": "SRV-01",
+        "status": "Maintenance",
+        "primary-ip": "172.16.20.50",
+        "primary-mac-address": "00-16-3E-5D-78-FF",
+        "operating-system": "Windows Server 2022",
+        "processor": "AMD EPYC 7313",
+        "memory": "128 GB",
+        "storage": "4 TB RAID10",
+        "last-logged-in-user": "elliot.reid",
+        "notes": "Core application server for Globex secure services.",
+        "installed-at": "2022-06-11T08:00:00Z",
+        "warranty-expiration": "2025-06-11"
+      },
+      "relationships": {
+        "organization": {
+          "data": {
+            "type": "organizations",
+            "id": "2"
+          }
+        },
+        "location": {
+          "data": {
+            "type": "locations",
+            "id": "2"
+          }
+        },
+        "configuration-type": {
+          "data": {
+            "type": "configuration-types",
+            "id": "2"
+          }
+        },
+        "primary-contact": {
+          "data": {
+            "type": "contacts",
+            "id": "2"
+          }
+        },
+        "passwords": {
+          "data": []
+        }
+      }
+    }
+  ]
+}

--- a/src/main/resources/data/contacts.json
+++ b/src/main/resources/data/contacts.json
@@ -1,0 +1,42 @@
+{
+  "data": [
+    {
+      "type": "contacts",
+      "id": "1",
+      "attributes": {
+        "first-name": "Maria",
+        "last-name": "Lopez",
+        "title": "IT Manager",
+        "email": "maria.lopez@acme.example.com",
+        "mobile-phone": "+1-555-100-2000"
+      },
+      "relationships": {
+        "organization": {
+          "data": {
+            "type": "organizations",
+            "id": "1"
+          }
+        }
+      }
+    },
+    {
+      "type": "contacts",
+      "id": "2",
+      "attributes": {
+        "first-name": "Elliot",
+        "last-name": "Reid",
+        "title": "Security Analyst",
+        "email": "elliot.reid@globex.example.com",
+        "mobile-phone": "+1-555-200-3000"
+      },
+      "relationships": {
+        "organization": {
+          "data": {
+            "type": "organizations",
+            "id": "2"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/src/main/resources/data/locations.json
+++ b/src/main/resources/data/locations.json
@@ -1,0 +1,44 @@
+{
+  "data": [
+    {
+      "type": "locations",
+      "id": "1",
+      "attributes": {
+        "name": "Acme HQ",
+        "address1": "123 Industrial Way",
+        "city": "Springfield",
+        "state": "IL",
+        "postal-code": "62701",
+        "country": "USA"
+      },
+      "relationships": {
+        "organization": {
+          "data": {
+            "type": "organizations",
+            "id": "1"
+          }
+        }
+      }
+    },
+    {
+      "type": "locations",
+      "id": "2",
+      "attributes": {
+        "name": "Globex Support Center",
+        "address1": "900 Innovation Dr",
+        "city": "Metropolis",
+        "state": "NY",
+        "postal-code": "10001",
+        "country": "USA"
+      },
+      "relationships": {
+        "organization": {
+          "data": {
+            "type": "organizations",
+            "id": "2"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/src/main/resources/data/organizations.json
+++ b/src/main/resources/data/organizations.json
@@ -1,0 +1,28 @@
+{
+  "data": [
+    {
+      "type": "organizations",
+      "id": "1",
+      "attributes": {
+        "name": "Acme Manufacturing",
+        "short-name": "Acme",
+        "created-at": "2022-01-05T15:24:00Z",
+        "updated-at": "2024-09-18T10:15:00Z",
+        "primary-domain": "acme.example.com",
+        "description": "Primary customer organization used for workstation support PoC"
+      }
+    },
+    {
+      "type": "organizations",
+      "id": "2",
+      "attributes": {
+        "name": "Globex Services",
+        "short-name": "Globex",
+        "created-at": "2021-07-12T08:00:00Z",
+        "updated-at": "2024-10-02T11:45:00Z",
+        "primary-domain": "globex.example.com",
+        "description": "Secondary organization used to demonstrate search filtering"
+      }
+    }
+  ]
+}

--- a/src/main/resources/data/passwords.json
+++ b/src/main/resources/data/passwords.json
@@ -1,0 +1,40 @@
+{
+  "data": [
+    {
+      "type": "passwords",
+      "id": "1",
+      "attributes": {
+        "name": "Local Administrator",
+        "username": "ACME\\administrator",
+        "password": "Passw0rd!",
+        "notes": "Rotated quarterly."
+      },
+      "relationships": {
+        "organization": {
+          "data": {
+            "type": "organizations",
+            "id": "1"
+          }
+        }
+      }
+    },
+    {
+      "type": "passwords",
+      "id": "2",
+      "attributes": {
+        "name": "Firebox Admin",
+        "username": "firewall_admin",
+        "password": "Sup3rSecure",
+        "notes": "Used for firewall troubleshooting scenarios."
+      },
+      "relationships": {
+        "organization": {
+          "data": {
+            "type": "organizations",
+            "id": "1"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/src/test/java/com/example/itgluemock/ItGlueMockApplicationTests.java
+++ b/src/test/java/com/example/itgluemock/ItGlueMockApplicationTests.java
@@ -1,0 +1,50 @@
+package com.example.itgluemock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class ItGlueMockApplicationTests {
+
+    @Autowired private MockMvc mockMvc;
+
+    @Autowired private ObjectMapper objectMapper;
+
+    @Test
+    void searchReturnsConfigurationMatch() throws Exception {
+        MvcResult result =
+                mockMvc.perform(get("/search").param("query", "acme"))
+                        .andExpect(status().isOk())
+                        .andReturn();
+
+        JsonNode response = objectMapper.readTree(result.getResponse().getContentAsString());
+        assertThat(response.path("data")).isNotEmpty();
+        assertThat(response.path("data").get(0).path("attributes").path("name").asText())
+                .containsIgnoringCase("acme");
+    }
+
+    @Test
+    void configurationIncludeOrganization() throws Exception {
+        MvcResult result =
+                mockMvc.perform(get("/configurations/100").param("include", "organization"))
+                        .andExpect(status().isOk())
+                        .andReturn();
+
+        JsonNode response = objectMapper.readTree(result.getResponse().getContentAsString());
+        JsonNode included = response.path("included");
+        assertThat(included).isNotNull();
+        assertThat(included).isNotEmpty();
+        assertThat(included.get(0).path("type").asText()).isEqualTo("organizations");
+    }
+}


### PR DESCRIPTION
## Summary
- create a Spring Boot service that mocks key IT Glue JSON:API endpoints, including search, resource collections, and relationship routes
- load mock data from editable JSON fixture files and support JSON:API include handling for related records
- add integration-style tests that cover search and configuration retrieval along with developer documentation for running the server

## Testing
- `mvn -q test` *(fails: network is unreachable when resolving Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68cd2900c5fc83268cfb99ac6f2db2b4